### PR TITLE
trim trailing slash for findNode path to get correct node hash

### DIFF
--- a/src/TQ/Git/Repository/Repository.php
+++ b/src/TQ/Git/Repository/Repository.php
@@ -783,6 +783,10 @@ class Repository extends AbstractRepository
      */
     public function findNode($file, $ref = 'HEAD')
     {
+        // make sure there's no trailing slash, which will list
+        // the child tree nodes rather than the tree node itself
+        $file = rtrim($file, "/");
+
         /** @var $result CallResult */
         $result = $this->getGit()->{'ls-tree'}($this->getRepositoryPath(), array(
             $ref,


### PR DESCRIPTION
So that `git ls-tree folder/` will return same output as `git ls-tree folder`, which should be the node hash for the actual directory, instead of the first child.
